### PR TITLE
the port for the server is required to be an integer

### DIFF
--- a/libvirt_exporter/cli.py
+++ b/libvirt_exporter/cli.py
@@ -19,6 +19,6 @@ def main():
           default='0.0.0.0')
     options = p.parse_args()
     REGISTRY.register(LibvirtCollector(options.uri))
-    start_http_server(options.port, addr=options.host)
+    start_http_server(int(options.port), addr=options.host)
     while (True):
         time.sleep(10000)


### PR DESCRIPTION
When the port is passed via the CLI/ENV the server did encounter issues during startup

```
 Traceback (most recent call last):
   File "libvirt_exporter", line 4, in <module>
   File "libvirt_exporter/cli.py", line 22, in main
   File "site-packages/prometheus_client/exposition.py", line 193, in start_http_server
   File "socketserver.py", line 452, in __init__
   File "http/server.py", line 137, in server_bind
   File "socketserver.py", line 466, in server_bind
 TypeError: an integer is required (got type str)
```